### PR TITLE
Add example env config for NextAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="file:./dev.db"
+NEXTAUTH_SECRET="your-secret"
+NEXTAUTH_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment variables
+
+Copy `.env.example` to `.env` and adjust the values for your setup. In particular, set `NEXTAUTH_URL` to the actual domain of your deployment to avoid redirecting to `http://localhost:3000` during sign in.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- add `.env.example` with NEXTAUTH_URL to configure auth callbacks
- explain environment variables in README
- allow committing `.env.example`

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cc34d22c88333ae1947e13eeb5fde