### PR TITLE
Remove invalid <html> wrapper in error page

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,14 +2,12 @@
 
 export default function GlobalError({ error }: { error: Error }) {
   return (
-    <html>
-      <body>
-        <main className="mx-auto max-w-5xl p-16">
-          <h1 className="text-3xl font-semibold">Something went wrong</h1>
-          <pre className="bg-gray-100 p-4 rounded mt-4 overflow-auto">{String(error?.stack || error?.message)}</pre>
-        </main>
-      </body>
-    </html>
+    <div className="mx-auto max-w-5xl p-16">
+      <h1 className="text-3xl font-semibold">Something went wrong</h1>
+      <pre className="bg-gray-100 p-4 rounded mt-4 overflow-auto">
+        {String(error?.stack || error?.message)}
+      </pre>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- fix `<div>` containing nested `<html>` by removing `<html>/<body>` wrappers from `app/error.tsx`

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689cf6e5bcc48333a52627cb0a08baea