### PR TITLE
fix: remove html wrapper from error component

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,14 +2,12 @@
 
 export default function GlobalError({ error }: { error: Error }) {
   return (
-    <html>
-      <body>
-        <main className="mx-auto max-w-5xl p-16">
-          <h1 className="text-3xl font-semibold">Something went wrong</h1>
-          <pre className="bg-gray-100 p-4 rounded mt-4 overflow-auto">{String(error?.stack || error?.message)}</pre>
-        </main>
-      </body>
-    </html>
+    <main className="mx-auto max-w-5xl p-16">
+      <h1 className="text-3xl font-semibold">Something went wrong</h1>
+      <pre className="bg-gray-100 p-4 rounded mt-4 overflow-auto">
+        {String(error?.stack || error?.message)}
+      </pre>
+    </main>
   );
 }
 


### PR DESCRIPTION
## Summary
- avoid mounting extra `<html>` element in global error page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npx eslint src/app/error.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cf6f1a34883339cc378e8744a8f76