### PR TITLE
fix: remove invalid html nesting

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,14 +2,12 @@
 
 export default function GlobalError({ error }: { error: Error }) {
   return (
-    <html>
-      <body>
-        <main className="mx-auto max-w-5xl p-16">
-          <h1 className="text-3xl font-semibold">Something went wrong</h1>
-          <pre className="bg-gray-100 p-4 rounded mt-4 overflow-auto">{String(error?.stack || error?.message)}</pre>
-        </main>
-      </body>
-    </html>
+    <div className="mx-auto max-w-5xl p-16">
+      <h1 className="text-3xl font-semibold">Something went wrong</h1>
+      <pre className="bg-gray-100 p-4 rounded mt-4 overflow-auto">
+        {String(error?.stack || error?.message)}
+      </pre>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove nested html & body tags from app error boundary

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx eslint src/app/error.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cf6d7f1a48333ad257ab46c9faad0