### PR TITLE
feat: refine UI with Jewel branding

### DIFF
--- a/src/app/admin/employees/page.tsx
+++ b/src/app/admin/employees/page.tsx
@@ -66,7 +66,7 @@ export default async function EmployeesPage() {
         </div>
       </form>
 
-      <div className="divide-y border border-panel rounded bg-panel">
+      <div className="divide-y border border-brand/20 rounded-xl bg-panel shadow-md">
         {employees.map(e => (
           <div key={e.id} className="flex items-center justify-between p-3">
             <div>
@@ -76,7 +76,7 @@ export default async function EmployeesPage() {
             </div>
             <form action={deleteEmployee} method="post">
               <input type="hidden" name="id" value={e.id} />
-              <Button type="submit" variant="destructive">Delete</Button>
+              <Button type="submit" variant="danger">Delete</Button>
             </form>
           </div>
         ))}

--- a/src/app/admin/facilities/page.tsx
+++ b/src/app/admin/facilities/page.tsx
@@ -48,13 +48,13 @@ export default async function FacilitiesPage() {
         <Button type="submit">Add</Button>
       </form>
 
-      <div className="divide-y border border-panel rounded bg-panel">
+      <div className="divide-y border border-brand/20 rounded-xl bg-panel shadow-md">
         {facilities.map(f => (
           <div key={f.id} className="flex items-center justify-between p-3">
             <div>{f.name}</div>
             <form action={deleteFacility} method="post">
               <input type="hidden" name="id" value={f.id} />
-              <Button type="submit" variant="destructive">Delete</Button>
+              <Button type="submit" variant="danger">Delete</Button>
             </form>
           </div>
         ))}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -24,9 +24,9 @@ export default async function AdminHome() {
     <main className="space-y-6">
       <h1 className="text-2xl font-semibold">Admin Dashboard</h1>
       <div className="grid sm:grid-cols-3 gap-4">
-        <Stat label="Facilities" value={facilityCount} />
-        <Stat label="Employees" value={employeeCount} />
-        <Stat label="Surveys" value={surveyCount} />
+        <Stat label="Facilities" value={facilityCount} icon="🏥" />
+        <Stat label="Employees" value={employeeCount} icon="👥" />
+        <Stat label="Surveys" value={surveyCount} icon="📋" />
       </div>
     </main>
   );

--- a/src/app/admin/surveys/page.tsx
+++ b/src/app/admin/surveys/page.tsx
@@ -45,9 +45,9 @@ export default async function SurveysPage() {
           const href = `/survey/${s.id}`;
           const qr = await QRCode.toDataURL(href);
           return (
-            <li key={s.id} className="border border-panel rounded bg-panel p-4">
+            <li key={s.id} className="border border-brand/20 rounded-xl bg-panel p-4 shadow-md transition hover:shadow-lg">
               <div className="flex items-start gap-4">
-                <Image src={qr} alt="QR" width={96} height={96} className="w-24 h-24 border border-panel rounded bg-white" unoptimized />
+                <Image src={qr} alt="QR" width={96} height={96} className="w-24 h-24 border border-brand/20 rounded bg-white" unoptimized />
                 <div className="flex-1">
                   <div className="font-medium">{s.title}</div>
                   <div className="text-sm text-teal-100/60">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,18 +25,21 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 :root {
-  --bg: #0B1115;
-  --panel: rgba(255,255,255,0.06);
-  --ring: #22D3EE33;
+  --color-brand: #0EA5A6;
+  --color-brand-dark: #0B7B7E;
+  --color-accent: #5EEAD4;
+  --bg: #0B0C10;
+  --panel: #121317;
+  --ring: #5EEAD444;
 }
-html, body { background: var(--bg); color: #e6f8f9; }
-a { color: #8CEAEC; }
+html, body { background: var(--bg); color: #f0f9f9; }
+a { color: var(--color-accent); }
 .bg-panel { background: var(--panel); }
-.border-panel { border-color: rgba(255,255,255,0.12); }
+.border-panel { border-color: rgba(255,255,255,0.1); }
 .glass { backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
 .grad-hero {
   background:
-    radial-gradient(1200px 600px at 20% -10%, #22D3EE22 0%, transparent 60%),
-    radial-gradient(1000px 500px at 100% 0%, #0EA5A644 0%, transparent 55%);
+    radial-gradient(1200px 600px at 20% -10%, var(--color-accent)22 0%, transparent 60%),
+    radial-gradient(1000px 500px at 100% 0%, var(--color-brand)44 0%, transparent 55%);
 }
 input, select, textarea { color-scheme: dark; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,22 @@
+import Link from "next/link";
 import { Stat } from "@/components/ui/Card";
+import { buttonVariants } from "@/components/ui/Button";
 
 export default function Home() {
   return (
     <>
-      <section className="rounded-3xl bg-panel glass border border-panel p-10">
+      <section className="rounded-xl bg-panel glass border border-brand/20 p-10 shadow-md">
         <h1 className="text-3xl font-semibold mb-2">Welcome to Project CrackDown</h1>
         <p className="text-teal-100/80 max-w-2xl">Manage facilities, staff, and lightweight surveys. Fast, secure, on-brand.</p>
         <div className="mt-6 flex gap-3">
-          <a href="/login" className="px-4 py-2 rounded-lg bg-brand hover:bg-brand-dark text-white border border-panel">Sign in</a>
-          <a href="/admin" className="px-4 py-2 rounded-lg bg-transparent border border-panel hover:bg-panel">Admin</a>
+          <Link href="/login" className={buttonVariants("primary")}>Sign in</Link>
+          <Link href="/admin" className={buttonVariants("secondary")}>Admin</Link>
         </div>
       </section>
-      <section className="grid sm:grid-cols-3 gap-4">
-        <Stat label="Uptime" value="99.9%" />
-        <Stat label="Security" value="SOC2-ready" />
-        <Stat label="Latency" value="<100ms" />
+      <section className="grid sm:grid-cols-3 gap-4 mt-8">
+        <Stat label="Uptime" value="99.9%" icon="✅" />
+        <Stat label="Security" value="SOC2-ready" icon="🛡️" />
+        <Stat label="Latency" value="<100ms" icon="⚡" />
       </section>
     </>
   );

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -2,20 +2,35 @@ import Image from "next/image";
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/options";
+import { buttonVariants } from "./ui/Button";
 
 export default async function AppNav() {
   const session = await getServerSession(authOptions);
   const role = (session?.user as { role?: string } | undefined)?.role;
 
   return (
-    <header className="sticky top-0 z-40 grad-hero border-b border-panel">
+    <header className="sticky top-0 z-40 bg-gradient-to-r from-brand to-brand-dark shadow-md">
       <nav className="container flex items-center justify-between py-4">
         <Link href="/" className="flex items-center gap-3">
           <Image src="/brand/jewel-logo.svg" alt="Jewel Healthcare" width={180} height={36} priority />
         </Link>
-        <div className="flex items-center gap-5 text-sm">
-          {role === "ADMIN" && <Link href="/admin" className="hover:underline">Admin</Link>}
-          <Link href="/api/auth/signout" className="hover:underline">Sign out</Link>
+        <div className="flex items-center gap-3">
+          {session ? (
+            <>
+              {role === "ADMIN" && (
+                <Link href="/admin" className={buttonVariants("secondary")}>
+                  Admin
+                </Link>
+              )}
+              <Link href="/api/auth/signout" className={buttonVariants("secondary")}>
+                Sign out
+              </Link>
+            </>
+          ) : (
+            <Link href="/login" className={buttonVariants("primary")}>
+              Sign in
+            </Link>
+          )}
         </div>
       </nav>
     </header>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,12 +1,18 @@
 import React from "react";
-type V = "primary"|"ghost"|"destructive";
+type V = "primary" | "secondary" | "danger";
 type P = React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: V; loading?: boolean; };
-export default function Button({ className="", variant="primary", loading=false, children, ...props }: P) {
-  const base = "inline-flex items-center justify-center rounded-lg px-3 py-2 text-sm font-medium transition border border-panel focus:outline-none focus:ring-4 focus:ring-[var(--ring)] disabled:opacity-50";
-  const styles: Record<V,string> = {
-    primary: "bg-brand text-white hover:bg-brand-dark",
-    ghost: "bg-transparent hover:bg-panel",
-    destructive: "bg-red-600 text-white hover:bg-red-700"
-  };
-  return <button {...props} className={`${base} ${styles[variant]} ${className}`}>{loading ? "…" : children}</button>;
+const base =
+  "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-transform shadow-sm hover:shadow-md hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] disabled:opacity-50";
+const styles: Record<V, string> = {
+  primary: "bg-brand text-white hover:bg-brand-dark",
+  secondary: "border border-brand text-brand hover:bg-brand/10",
+  danger: "bg-red-600 text-white hover:bg-red-700",
+};
+export const buttonVariants = (variant: V = "primary") => `${base} ${styles[variant]}`;
+export default function Button({ className = "", variant = "primary", loading = false, children, ...props }: P) {
+  return (
+    <button {...props} className={`${buttonVariants(variant)} ${className}`}>
+      {loading ? "…" : children}
+    </button>
+  );
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,15 +1,32 @@
 import React from "react";
-export function Card({ children, className="" }: { children: React.ReactNode; className?: string }) {
-  return <div className={`bg-panel glass shadow-glass border border-panel rounded-2xl ${className}`}>{children}</div>;
+export function Card({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={`bg-panel glass border border-brand/20 rounded-xl shadow-md transition hover:shadow-lg hover:scale-[1.01] ${className}`}
+    >
+      {children}
+    </div>
+  );
 }
-export function CardBody({ children, className="" }: { children: React.ReactNode; className?: string }) {
+export function CardBody({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return <div className={`p-5 ${className}`}>{children}</div>;
 }
-export function Stat({ label, value }: { label: string; value: string | number }) {
+export function Stat({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string | number;
+  icon?: React.ReactNode;
+}) {
   return (
-    <div className="p-4 rounded-xl bg-panel border border-panel">
-      <div className="text-xs uppercase tracking-wider text-teal-200/70">{label}</div>
-      <div className="text-2xl font-semibold mt-1">{value}</div>
+    <div className="p-4 rounded-xl bg-panel border border-brand/20 flex items-center gap-3 shadow-sm transition hover:shadow-md hover:scale-[1.02]">
+      {icon && <div className="text-brand text-xl">{icon}</div>}
+      <div>
+        <div className="text-xs uppercase tracking-wider text-brand">{label}</div>
+        <div className="text-2xl font-semibold mt-1">{value}</div>
+      </div>
     </div>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,7 +5,13 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        brand: { DEFAULT: "#0EA5A6", dark: "#0B7B7E", light: "#22D3EE", bg: "#0B1115", panel: "rgba(255,255,255,0.06)" }
+        brand: {
+          DEFAULT: "#0EA5A6",
+          dark: "#0B7B7E",
+          light: "#5EEAD4",
+          bg: "#0B0C10",
+          panel: "#121317"
+        }
       },
       boxShadow: {
         glass: "0 1px 0 rgba(255,255,255,0.08) inset, 0 10px 30px rgba(0,0,0,0.35)"


### PR DESCRIPTION
## Summary
- add brand color variables and update dark theme styling
- introduce reusable button variants and gradient header
- refresh cards and stats with icons and subtle hover effects

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e398a82d48333abe72491dd165a8f