### PR TITLE
feat: adopt brand colors for UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,11 +28,14 @@ body {
   --color-brand: #0EA5A6;
   --color-brand-dark: #0B7B7E;
   --color-accent: #5EEAD4;
-  --bg: #0B0C10;
-  --panel: #121317;
+  --bg: #0B7B7E;
+  --panel: #0EA5A6;
   --ring: #5EEAD444;
 }
-html, body { background: var(--bg); color: #f0f9f9; }
+html, body {
+  background: linear-gradient(to bottom, var(--color-brand), var(--color-brand-dark));
+  color: #f0f9f9;
+}
 a { color: var(--color-accent); }
 .bg-panel { background: var(--panel); }
 .border-panel { border-color: rgba(255,255,255,0.1); }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,8 +9,8 @@ const config: Config = {
           DEFAULT: "#0EA5A6",
           dark: "#0B7B7E",
           light: "#5EEAD4",
-          bg: "#0B0C10",
-          panel: "#121317"
+          bg: "#0B7B7E",
+          panel: "#0EA5A6"
         }
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- replace black theme with branded teal palette
- update Tailwind config to reflect brand colors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e3debee3083339d0b0230f71f6cb1