### PR TITLE
feat: add survey builder and creation flow

### DIFF
--- a/prisma/migrations/20250814201016_survey_builder/migration.sql
+++ b/prisma/migrations/20250814201016_survey_builder/migration.sql
@@ -1,0 +1,21 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Survey" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "allowAnon" BOOLEAN NOT NULL DEFAULT true,
+    "startsAt" DATETIME,
+    "endsAt" DATETIME,
+    "questions" JSONB,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_Survey" ("createdAt", "createdBy", "id", "title") SELECT "createdAt", "createdBy", "id", "title" FROM "Survey";
+DROP TABLE "Survey";
+ALTER TABLE "new_Survey" RENAME TO "Survey";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,12 +44,26 @@ enum StaffType {
   AGENCY
 }
 
+enum SurveyStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
 model Survey {
-  id        String           @id @default(cuid())
-  title     String
-  createdBy String
-  createdAt DateTime         @default(now())
-  responses SurveyResponse[]
+  id           String       @id @default(cuid())
+  title        String
+  description  String?
+  status       SurveyStatus @default(DRAFT)
+  allowAnon    Boolean      @default(true)
+  startsAt     DateTime?
+  endsAt       DateTime?
+  questions    Json?        // array of Question objects
+  createdBy    String
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @default(now()) @updatedAt
+
+  responses    SurveyResponse[]
 }
 
 model SurveyResponse {

--- a/src/app/admin/surveys/new/page.tsx
+++ b/src/app/admin/surveys/new/page.tsx
@@ -1,0 +1,58 @@
+import { redirect } from "next/navigation";
+import { requireAdmin } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import SurveyBuilder from "@/components/surveys/Builder";
+import Button from "@/components/ui/Button";
+import { Card, CardBody } from "@/components/ui/Card";
+import type { SurveyDraft } from "@/types/survey";
+
+export default async function NewSurveyPage() {
+  await requireAdmin();
+
+  async function create(formData: FormData) {
+    "use server";
+    const session = await requireAdmin();
+    const raw = String(formData.get("draft") || "{}");
+    let draft: SurveyDraft;
+    try { draft = JSON.parse(raw) as SurveyDraft; } catch { throw new Error("Invalid form payload"); }
+
+    if (!draft.title?.trim()) throw new Error("Title is required");
+    if ((draft.startsAt && draft.endsAt) && new Date(draft.startsAt) > new Date(draft.endsAt)) {
+      throw new Error("Opens must be before Closes");
+    }
+
+    await prisma.survey.create({
+      data: {
+        title: draft.title.trim(),
+        description: draft.description || null,
+        status: draft.status,
+        allowAnon: !!draft.allowAnon,
+        startsAt: draft.startsAt ? new Date(draft.startsAt) : null,
+        endsAt: draft.endsAt ? new Date(draft.endsAt) : null,
+        questions: draft.questions ?? [],
+        createdBy: session.user?.email || "admin",
+      },
+    });
+
+    redirect(`/admin/surveys`);
+  }
+
+  return (
+    <main className="space-y-6">
+      <h1 className="text-2xl font-semibold">New Survey</h1>
+      <Card>
+        <CardBody>
+          <form action={create} method="post" id="create-survey-form" className="space-y-6">
+            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+            {/* @ts-ignore Client Component */}
+            <SurveyBuilder />
+            <div className="flex gap-2">
+              <Button type="submit">Create survey</Button>
+              <a href="/admin/surveys" className="px-3 py-2 rounded-lg border border-panel hover:bg-panel">Cancel</a>
+            </div>
+          </form>
+        </CardBody>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/admin/surveys/page.tsx
+++ b/src/app/admin/surveys/page.tsx
@@ -34,7 +34,12 @@ export default async function SurveysPage() {
 
   return (
     <main className="space-y-6">
-      <h1 className="text-2xl font-semibold">Surveys</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Surveys</h1>
+        <a href="/admin/surveys/new">
+          <Button type="button">Create survey</Button>
+        </a>
+      </div>
       <form action={createSurvey} method="post" className="flex gap-2 max-w-xl">
         <Input name="title" placeholder="New survey title" />
         <Button type="submit">Create</Button>

--- a/src/app/survey/[id]/page.tsx
+++ b/src/app/survey/[id]/page.tsx
@@ -1,27 +1,32 @@
-import type { Prisma } from "@prisma/client";
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { notFound, redirect } from "next/navigation";
+import prisma from "@/lib/prisma";
+import type { Question } from "@/types/survey";
 import { Card, CardBody } from "@/components/ui/Card";
+import Input from "@/components/ui/Input";
 import Textarea from "@/components/ui/Textarea";
 import Button from "@/components/ui/Button";
-import prisma from "@/lib/prisma";
 
-export default async function PublicSurvey({ params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<Record<string, string>>; }) {
+export default async function PublicSurvey({ params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<Record<string,string>>; }) {
   const { id } = await params;
   const sp = await searchParams;
   const survey = await prisma.survey.findUnique({ where: { id } });
   if (!survey) notFound();
   const surveyId = survey.id;
+  const questions = (survey.questions as Question[] | null) ?? [];
 
   async function submit(formData: FormData) {
     "use server";
-    const payloadTxt = String(formData.get("payload") || "{}");
-    let json: Prisma.JsonValue = {};
-    try {
-      json = JSON.parse(payloadTxt) as Prisma.JsonValue;
-    } catch {
-      json = { text: payloadTxt };
+    const entries: Record<string, any> = {};
+    for (const q of questions) {
+      const key = `q_${q.id}`;
+      if (q.type === "select" && (q as any).multiple) entries[q.label] = formData.getAll(key);
+      else if (q.type === "yes_no") entries[q.label] = formData.get(key) === "yes";
+      else if (q.type === "rating") {
+        const v = Number(formData.get(key)); entries[q.label] = Number.isFinite(v) ? v : null;
+      } else { entries[q.label] = formData.get(key); }
     }
-    await prisma.surveyResponse.create({ data: { surveyId, payload: json as Prisma.InputJsonValue } });
+    await prisma.surveyResponse.create({ data: { surveyId, payload: entries } });
     redirect(`/survey/${surveyId}?ok=1`);
   }
 
@@ -29,10 +34,42 @@ export default async function PublicSurvey({ params, searchParams }: { params: P
     <Card className="max-w-3xl mx-auto">
       <CardBody>
         <h1 className="text-xl font-semibold">{survey.title}</h1>
+        {survey.description && <p className="text-sm text-teal-100/80 mt-1">{survey.description}</p>}
         {sp?.ok && <div className="mt-3 text-sm text-teal-200">Thanks! Response recorded.</div>}
-        <p className="text-sm text-teal-100/70 mt-2">Paste JSON or type text; we’ll store it as JSON.</p>
-        <form action={submit} method="post" className="space-y-3 mt-4">
-          <Textarea name="payload" rows={10} placeholder='{"answer":"Yes"}' />
+
+        <form action={submit} method="post" className="space-y-4 mt-6">
+          {questions.map(q => (
+            <div key={q.id} className="space-y-1">
+              <label className="text-sm font-medium">{q.label}{q.required ? " *" : ""}</label>
+              {q.helpText && <div className="text-xs text-teal-100/70">{q.helpText}</div>}
+              {q.type === "short_text" && <Input name={`q_${q.id}`} required={!!q.required} placeholder={(q as any).placeholder || ""} />}
+              {q.type === "long_text"  && <Textarea name={`q_${q.id}`} required={!!q.required} rows={4} placeholder={(q as any).placeholder || ""} />}
+              {q.type === "yes_no" && (
+                <div className="flex gap-4">
+                  <label className="flex items-center gap-2 text-sm"><input type="radio" name={`q_${q.id}`} value="yes" required={!!q.required} /> Yes</label>
+                  <label className="flex items-center gap-2 text-sm"><input type="radio" name={`q_${q.id}`} value="no"  required={!!q.required} /> No</label>
+                </div>
+              )}
+              {q.type === "rating" && (
+                <select name={`q_${q.id}`} required={!!q.required} className="w-32 rounded-lg bg-panel border border-panel px-3 py-2">
+                  <option value="">Select…</option>
+                  {Array.from({ length: (q as any).max ?? 5 }, (_, i) => i+1).map(n => <option key={n} value={n}>{n}</option>)}
+                </select>
+              )}
+              {q.type === "select" && (
+                (q as any).multiple ? (
+                  <select name={`q_${q.id}`} multiple className="w-full rounded-lg bg-panel border border-panel px-3 py-2">
+                    {(q as any).options?.map((opt: string, idx: number) => <option key={idx} value={opt}>{opt}</option>)}
+                  </select>
+                ) : (
+                  <select name={`q_${q.id}`} required={!!q.required} className="w-full rounded-lg bg-panel border border-panel px-3 py-2">
+                    <option value="">Select…</option>
+                    {(q as any).options?.map((opt: string, idx: number) => <option key={idx} value={opt}>{opt}</option>)}
+                  </select>
+                )
+              )}
+            </div>
+          ))}
           <Button type="submit">Submit</Button>
         </form>
       </CardBody>

--- a/src/components/surveys/Builder.tsx
+++ b/src/components/surveys/Builder.tsx
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+"use client";
+import React, { useId, useMemo, useState } from "react";
+import type { Question, QuestionType, SurveyDraft } from "@/types/survey";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Textarea from "@/components/ui/Textarea";
+import Select from "@/components/ui/Select";
+
+function cuid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+const TEMPLATE_BY_TYPE: Record<QuestionType, () => Question> = {
+  short_text: () => ({ id: cuid(), type: "short_text", label: "Short answer", required: false, helpText: "", placeholder: "" }),
+  long_text:  () => ({ id: cuid(), type: "long_text",  label: "Long answer",  required: false, helpText: "", placeholder: "" }),
+  yes_no:     () => ({ id: cuid(), type: "yes_no",     label: "Yes / No",     required: false, helpText: "" }),
+  rating:     () => ({ id: cuid(), type: "rating",     label: "Rating",       required: false, helpText: "", max: 5 }),
+  select:     () => ({ id: cuid(), type: "select",     label: "Select",       required: false, helpText: "", options: ["Option 1"], multiple: false }),
+};
+
+type Props = { initial?: Partial<SurveyDraft> };
+
+export default function SurveyBuilder({ initial }: Props) {
+  const formId = useId();
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [status, setStatus] = useState<"DRAFT" | "PUBLISHED" | "ARCHIVED">(initial?.status ?? "DRAFT");
+  const [allowAnon, setAllowAnon] = useState<boolean>(initial?.allowAnon ?? true);
+  const [startsAt, setStartsAt] = useState<string>(initial?.startsAt ?? "");
+  const [endsAt, setEndsAt] = useState<string>(initial?.endsAt ?? "");
+  const [questions, setQuestions] = useState<Question[]>(initial?.questions ?? []);
+
+  function addQuestion(type: QuestionType) { setQuestions(qs => [...qs, TEMPLATE_BY_TYPE[type]()]); }
+  function updateQuestion(id: string, patch: Partial<Question>) { setQuestions(qs => qs.map(q => q.id === id ? { ...q, ...patch } as Question : q)); }
+  function removeQuestion(id: string) { setQuestions(qs => qs.filter(q => q.id !== id)); }
+  function moveQuestion(id: string, dir: -1 | 1) {
+    setQuestions(qs => {
+      const i = qs.findIndex(q => q.id === id);
+      const j = i + dir;
+      if (i < 0 || j < 0 || j >= qs.length) return qs;
+      const copy = [...qs];
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+      return copy;
+    });
+  }
+
+  const asDraft: SurveyDraft = useMemo(() => ({
+    title, description, status, allowAnon,
+    startsAt: startsAt || undefined,
+    endsAt: endsAt || undefined,
+    questions,
+  }), [title, description, status, allowAnon, startsAt, endsAt, questions]);
+
+  return (
+    <div className="space-y-6">
+      <section className="grid md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-sm">Title</label>
+          <Input value={title} onChange={e=>setTitle(e.target.value)} placeholder="Resident Satisfaction – Week 32" required />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm">Status</label>
+          <Select value={status} onChange={(e)=>setStatus(e.target.value as any)}>
+            <option value="DRAFT">Draft</option>
+            <option value="PUBLISHED">Published</option>
+            <option value="ARCHIVED">Archived</option>
+          </Select>
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label className="text-sm">Description</label>
+          <Textarea rows={3} value={description} onChange={e=>setDescription(e.target.value)} placeholder="Optional context for participants…" />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm">Opens</label>
+          <Input type="datetime-local" value={startsAt} onChange={e=>setStartsAt(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm">Closes</label>
+          <Input type="datetime-local" value={endsAt} onChange={e=>setEndsAt(e.target.value)} />
+        </div>
+        <label className="flex items-center gap-2 text-sm md:col-span-2">
+          <input type="checkbox" checked={allowAnon} onChange={e=>setAllowAnon(e.target.checked)} />
+          Allow anonymous responses
+        </label>
+      </section>
+
+      <section className="space-y-3">
+        <div className="text-sm">Add question</div>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="secondary" onClick={()=>addQuestion("short_text")}>Short text</Button>
+          <Button type="button" variant="secondary" onClick={()=>addQuestion("long_text")}>Long text</Button>
+          <Button type="button" variant="secondary" onClick={()=>addQuestion("yes_no")}>Yes / No</Button>
+          <Button type="button" variant="secondary" onClick={()=>addQuestion("rating")}>Rating</Button>
+          <Button type="button" variant="secondary" onClick={()=>addQuestion("select")}>Select</Button>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        {questions.length === 0 && <div className="text-sm text-teal-100/70">No questions yet — add some above.</div>}
+        <ul className="space-y-3">
+          {questions.map((q, i) => (
+            <li key={q.id} className="bg-panel border border-panel rounded-xl p-4">
+              <div className="flex items-center justify-between">
+                <div className="text-xs uppercase tracking-wider text-teal-100/70">{q.type.replace("_"," ")}</div>
+                <div className="flex gap-2">
+                  <Button type="button" variant="secondary" onClick={()=>moveQuestion(q.id, -1)} disabled={i===0}>↑</Button>
+                  <Button type="button" variant="secondary" onClick={()=>moveQuestion(q.id, +1)} disabled={i===questions.length-1}>↓</Button>
+                  <Button type="button" variant="danger" onClick={()=>removeQuestion(q.id)}>Remove</Button>
+                </div>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-3 mt-3">
+                <div className="space-y-2">
+                  <label className="text-sm">Label</label>
+                  <Input value={q.label} onChange={(e)=>updateQuestion(q.id, { label: e.target.value })} />
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={!!q.required} onChange={e=>updateQuestion(q.id, { required: e.target.checked })} />
+                  Required
+                </label>
+                <div className="space-y-2 md:col-span-2">
+                  <label className="text-sm">Help text</label>
+                  <Input value={q.helpText ?? ""} onChange={(e)=>updateQuestion(q.id, { helpText: e.target.value })} placeholder="Shown under the label (optional)" />
+                </div>
+
+                {(q.type === "short_text" || q.type === "long_text") && (
+                  <div className="space-y-2 md:col-span-2">
+                    <label className="text-sm">Placeholder</label>
+                    <Input value={(q as any).placeholder ?? ""} onChange={(e)=>updateQuestion(q.id, { placeholder: e.target.value } as any)} />
+                  </div>
+                )}
+
+                {q.type === "rating" && (
+                  <div className="space-y-2">
+                    <label className="text-sm">Max</label>
+                    <Input type="number" min={3} max={10} value={(q as any).max ?? 5} onChange={(e)=>updateQuestion(q.id, { max: Number(e.target.value) } as any)} />
+                  </div>
+                )}
+
+                {q.type === "select" && (
+                  <div className="space-y-2 md:col-span-2">
+                    <label className="text-sm">Options (comma‑separated)</label>
+                    <Input value={(q as any).options?.join(", ") ?? ""} onChange={(e)=>updateQuestion(q.id, { options: e.target.value.split(",").map(s=>s.trim()).filter(Boolean) } as any)} placeholder="Yes, No, Maybe" />
+                    <label className="flex items-center gap-2 text-sm">
+                      <input type="checkbox" checked={!!(q as any).multiple} onChange={(e)=>updateQuestion(q.id, { multiple: e.target.checked } as any)} />
+                      Allow multiple selection
+                    </label>
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Hidden serializer for the server action form on the page */}
+      <input type="hidden" name="draft" value={JSON.stringify(asDraft)} form={formId} />
+    </div>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,21 @@
 import { getServerSession } from "next-auth";
+import type { Session } from "next-auth";
+import { redirect } from "next/navigation";
 import { authOptions } from "@/app/api/auth/[...nextauth]/options";
+
+export interface AppSession extends Session {
+  user?: Session["user"] & { role?: string; email?: string | null };
+}
 
 export function getSession() {
   return getServerSession(authOptions);
+}
+
+export async function requireAdmin() {
+  const session = (await getServerSession(authOptions)) as AppSession | null;
+  const role = session?.user?.role;
+  if (!session) redirect("/login");
+  if (role !== "ADMIN") redirect("/");
+  return session;
 }
 

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -1,0 +1,41 @@
+export type QuestionType = "short_text" | "long_text" | "yes_no" | "rating" | "select";
+
+export type BaseQuestion = {
+  id: string;
+  type: QuestionType;
+  label: string;
+  required?: boolean;
+  helpText?: string;
+};
+
+export type SelectQuestion = BaseQuestion & {
+  type: "select";
+  options: string[];
+  multiple?: boolean;
+};
+
+export type RatingQuestion = BaseQuestion & {
+  type: "rating";
+  max?: number;
+};
+
+export type ShortTextQuestion = BaseQuestion & { type: "short_text"; placeholder?: string };
+export type LongTextQuestion  = BaseQuestion & { type: "long_text";  placeholder?: string };
+export type YesNoQuestion     = BaseQuestion & { type: "yes_no" };
+
+export type Question =
+  | ShortTextQuestion
+  | LongTextQuestion
+  | YesNoQuestion
+  | RatingQuestion
+  | SelectQuestion;
+
+export type SurveyDraft = {
+  title: string;
+  description?: string;
+  status: "DRAFT" | "PUBLISHED" | "ARCHIVED";
+  allowAnon: boolean;
+  startsAt?: string;
+  endsAt?: string;
+  questions: Question[];
+};


### PR DESCRIPTION
## Summary
- extend Survey model with status, scheduling and question JSON
- add interactive SurveyBuilder component and admin create page
- render structured public survey and save responses

## Testing
- `npx prisma migrate dev --name survey_builder`
- `npm run lint`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689e3f678c288333acbfc97ea13cca74