### PR TITLE
Use neutral text colors and add survey thank-you page

### DIFF
--- a/src/app/admin/employees/page.tsx
+++ b/src/app/admin/employees/page.tsx
@@ -57,9 +57,9 @@ export default async function EmployeesPage() {
         {employees.map(e => (
           <div key={e.id} className="flex items-center justify-between p-3">
             <div>
-              <div className="font-medium">{e.name} <span className="text-xs text-teal-100/60">({e.staffType})</span></div>
-              <div className="text-sm text-teal-100/60">{e.facility?.name}</div>
-              {e.phone && <div className="text-sm text-teal-100/60">{e.phone}</div>}
+              <div className="font-medium">{e.name} <span className="text-xs text-gray-500">({e.staffType})</span></div>
+              <div className="text-sm text-gray-500">{e.facility?.name}</div>
+              {e.phone && <div className="text-sm text-gray-500">{e.phone}</div>}
             </div>
             <form action={deleteEmployee} method="post">
               <input type="hidden" name="id" value={e.id} />
@@ -67,7 +67,7 @@ export default async function EmployeesPage() {
             </form>
           </div>
         ))}
-        {employees.length === 0 && <div className="p-3 text-teal-100/60">No employees yet.</div>}
+        {employees.length === 0 && <div className="p-3 text-gray-500">No employees yet.</div>}
       </div>
     </main>
   );

--- a/src/app/admin/facilities/page.tsx
+++ b/src/app/admin/facilities/page.tsx
@@ -45,7 +45,7 @@ export default async function FacilitiesPage() {
             </form>
           </div>
         ))}
-        {facilities.length === 0 && <div className="p-3 text-teal-100/60">No facilities yet.</div>}
+        {facilities.length === 0 && <div className="p-3 text-gray-500">No facilities yet.</div>}
       </div>
     </main>
   );

--- a/src/app/admin/surveys/page.tsx
+++ b/src/app/admin/surveys/page.tsx
@@ -42,10 +42,10 @@ export default async function SurveysPage() {
                 <Image src={qr} alt="QR" width={96} height={96} className="w-24 h-24 border border-brand/20 rounded bg-white" unoptimized />
                 <div className="flex-1">
                   <div className="font-medium">{s.title}</div>
-                  <div className="text-sm text-teal-100/60">
+                  <div className="text-sm text-gray-500">
                     Link: <a className="underline" href={href}>{href}</a>
                   </div>
-                  <div className="text-sm text-teal-100/60">
+                  <div className="text-sm text-gray-500">
                     <a className="underline" href={`/api/export/survey/${s.id}`}>Download CSV</a>
                   </div>
                 </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #000000;
 }
 
 @theme inline {
@@ -15,7 +15,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #333333;
   }
 }
 
@@ -34,9 +34,9 @@ body {
 }
 html, body {
   background: linear-gradient(to bottom, var(--color-brand), var(--color-brand-dark));
-  color: #f0f9f9;
+  color: var(--foreground);
 }
-a { color: var(--color-accent); }
+a { color: var(--foreground); }
 .bg-panel { background: var(--panel); }
 .border-panel { border-color: rgba(255,255,255,0.1); }
 .glass { backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
@@ -45,4 +45,4 @@ a { color: var(--color-accent); }
     radial-gradient(1200px 600px at 20% -10%, var(--color-accent)22 0%, transparent 60%),
     radial-gradient(1000px 500px at 100% 0%, var(--color-brand)44 0%, transparent 55%);
 }
-input, select, textarea { color-scheme: dark; }
+input, select, textarea { color-scheme: light; }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
           <Input placeholder="Password" type="password" value={password} onChange={e=>setPassword(e.target.value)} />
           <Button onClick={()=>signIn("credentials", { email, password, callbackUrl: "/admin" })}>Continue</Button>
         </div>
-        <p className="text-xs text-teal-100/60 mt-4">Dev mode: password not validated; email must exist.</p>
+        <p className="text-xs text-gray-500 mt-4">Dev mode: password not validated; email must exist.</p>
       </CardBody>
     </Card>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
     <>
       <section className="rounded-xl bg-panel glass border border-brand/20 p-10 shadow-md">
         <h1 className="text-3xl font-semibold mb-2">Welcome to Project CrackDown</h1>
-        <p className="text-teal-100/80 max-w-2xl">Manage facilities, staff, and lightweight surveys. Fast, secure, on-brand.</p>
+        <p className="text-gray-600 max-w-2xl">Manage facilities, staff, and lightweight surveys. Fast, secure, on-brand.</p>
         <div className="mt-6 flex gap-3">
           <Link href="/login" className={buttonVariants("primary")}>Sign in</Link>
           <Link href="/admin" className={buttonVariants("secondary")}>Admin</Link>

--- a/src/app/survey/[id]/page.tsx
+++ b/src/app/survey/[id]/page.tsx
@@ -8,9 +8,8 @@ import Input from "@/components/ui/Input";
 import Textarea from "@/components/ui/Textarea";
 import Button from "@/components/ui/Button";
 
-export default async function PublicSurvey({ params, searchParams }: { params: Promise<{ id: string }>; searchParams: Promise<Record<string,string>>; }) {
+export default async function PublicSurvey({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const sp = await searchParams;
   const survey = await prisma.survey.findUnique({ where: { id } });
   if (!survey) notFound();
   const surveyId = survey.id;
@@ -29,21 +28,20 @@ export default async function PublicSurvey({ params, searchParams }: { params: P
       } else { entries[q.label] = formData.get(key); }
     }
     await prisma.surveyResponse.create({ data: { surveyId, payload: entries } });
-    redirect(`/survey/${surveyId}?ok=1`);
+    redirect(`/thank-you`);
   }
 
   return (
     <Card className="max-w-3xl mx-auto">
       <CardBody>
         <h1 className="text-xl font-semibold">{survey.title}</h1>
-        {survey.description && <p className="text-sm text-teal-100/80 mt-1">{survey.description}</p>}
-        {sp?.ok && <div className="mt-3 text-sm text-teal-200">Thanks! Response recorded.</div>}
+        {survey.description && <p className="text-sm text-gray-600 mt-1">{survey.description}</p>}
 
         <form action={submit} method="post" className="space-y-4 mt-6">
           {questions.map(q => (
             <div key={q.id} className="space-y-1">
               <label className="text-sm font-medium">{q.label}{q.required ? " *" : ""}</label>
-              {q.helpText && <div className="text-xs text-teal-100/70">{q.helpText}</div>}
+              {q.helpText && <div className="text-xs text-gray-500">{q.helpText}</div>}
               {q.type === "short_text" && <Input name={`q_${q.id}`} required={!!q.required} placeholder={(q as any).placeholder || ""} />}
               {q.type === "long_text"  && <Textarea name={`q_${q.id}`} required={!!q.required} rows={4} placeholder={(q as any).placeholder || ""} />}
               {q.type === "yes_no" && (

--- a/src/app/thank-you/page.tsx
+++ b/src/app/thank-you/page.tsx
@@ -1,0 +1,11 @@
+import Image from "next/image";
+
+export default function ThankYouPage() {
+  return (
+    <div className="text-center space-y-6">
+      <Image src="/brand/jewel-logo.svg" alt="Jewel Healthcare" width={200} height={40} className="mx-auto" />
+      <h1 className="text-3xl font-semibold">Thank you for your response</h1>
+      <p className="text-gray-600">We appreciate your feedback.</p>
+    </div>
+  );
+}

--- a/src/components/surveys/Builder.tsx
+++ b/src/components/surveys/Builder.tsx
@@ -152,12 +152,12 @@ export default function SurveyBuilder({ initial }: Props) {
       </section>
 
       <section className="space-y-3">
-        {questions.length === 0 && <div className="text-sm text-teal-100/70">No questions yet — add some above.</div>}
+        {questions.length === 0 && <div className="text-sm text-gray-500">No questions yet — add some above.</div>}
         <ul className="space-y-3">
           {questions.map((q, i) => (
             <li key={q.id} className="bg-panel border border-panel rounded-xl p-4">
               <div className="flex items-center justify-between">
-                <div className="text-xs uppercase tracking-wider text-teal-100/70">{q.type.replace("_"," ")}</div>
+                <div className="text-xs uppercase tracking-wider text-gray-500">{q.type.replace("_"," ")}</div>
                 <div className="flex gap-2">
                   <Button type="button" variant="secondary" onClick={()=>moveQuestion(q.id, -1)} disabled={i===0}>↑</Button>
                   <Button type="button" variant="secondary" onClick={()=>moveQuestion(q.id, +1)} disabled={i===questions.length-1}>↓</Button>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -4,9 +4,9 @@ type P = React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: V; loading?
 const base =
   "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-transform shadow-sm hover:shadow-md hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] disabled:opacity-50";
 const styles: Record<V, string> = {
-  primary: "bg-brand text-white hover:bg-brand-dark",
-  secondary: "border border-brand text-brand hover:bg-brand/10",
-  danger: "bg-red-600 text-white hover:bg-red-700",
+  primary: "bg-brand text-black hover:bg-brand-dark",
+  secondary: "border border-brand text-gray-700 hover:bg-brand/10",
+  danger: "bg-red-600 text-black hover:bg-red-700",
 };
 export const buttonVariants = (variant: V = "primary") => `${base} ${styles[variant]}`;
 export default function Button({ className = "", variant = "primary", loading = false, children, ...props }: P) {

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -22,9 +22,9 @@ export function Stat({
 }) {
   return (
     <div className="p-4 rounded-xl bg-panel border border-brand/20 flex items-center gap-3 shadow-sm transition hover:shadow-md hover:scale-[1.02]">
-      {icon && <div className="text-brand text-xl">{icon}</div>}
+      {icon && <div className="text-gray-700 text-xl">{icon}</div>}
       <div>
-        <div className="text-xs uppercase tracking-wider text-brand">{label}</div>
+        <div className="text-xs uppercase tracking-wider text-gray-500">{label}</div>
         <div className="text-2xl font-semibold mt-1">{value}</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Default to black and gray text across the app
- Redirect survey submissions to a branded thank-you page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a646e4e51c8333a8f18584fc62d1af